### PR TITLE
Feat: 添加跳转歌词页入口

### DIFF
--- a/miniprogram/components/episode/sp-content/index.js
+++ b/miniprogram/components/episode/sp-content/index.js
@@ -2,7 +2,7 @@
  * @Author: Lac
  * @Date: 2018-08-26 00:58:53
  * @Last Modified by: Lac
- * @Last Modified time: 2018-09-07 12:18:31
+ * @Last Modified time: 2018-09-07 12:25:14
  */
 
 import { episodeBeh } from '../beh.js'
@@ -49,10 +49,12 @@ Component({
     },
 
     handleClickTitle: function () {
-      const { index } = this.data.content
-      wx.navigateTo({
-        url: `/pages/lyric/index?index=${index}`
-      })
+      const { index, lyric } = this.data.content
+      if (lyric && lyric === 1) {
+        wx.navigateTo({
+          url: `/pages/lyric/index?index=${index}`
+        })
+      }
     },
 
     _recoverStatus: function () {

--- a/miniprogram/components/episode/sp-content/index.js
+++ b/miniprogram/components/episode/sp-content/index.js
@@ -2,7 +2,7 @@
  * @Author: Lac
  * @Date: 2018-08-26 00:58:53
  * @Last Modified by: Lac
- * @Last Modified time: 2018-08-26 18:28:57
+ * @Last Modified time: 2018-09-07 12:18:31
  */
 
 import { episodeBeh } from '../beh.js'
@@ -45,6 +45,13 @@ Component({
       }
       this.setData({
         playing: !playing
+      })
+    },
+
+    handleClickTitle: function () {
+      const { index } = this.data.content
+      wx.navigateTo({
+        url: `/pages/lyric/index?index=${index}`
       })
     },
 

--- a/miniprogram/components/episode/sp-content/index.wxml
+++ b/miniprogram/components/episode/sp-content/index.wxml
@@ -17,6 +17,9 @@
       class='text'
       data-content='{{ content.content }}'
       bind:longpress='handleLongPress'
-    >{{ content.content }}<text class='name' >-- {{ name }}</text></view>
+    >
+      {{ content.content }}
+      <text class='name' bind:tap='handleClickTitle' >-- {{ name }}</text>
+    </view>
   </view>
 </view>

--- a/miniprogram/pages/lyric/index.js
+++ b/miniprogram/pages/lyric/index.js
@@ -2,7 +2,7 @@
  * @Author: Lac
  * @Date: 2018-09-05 16:48:52
  * @Last Modified by: Lac
- * @Last Modified time: 2018-09-05 23:00:36
+ * @Last Modified time: 2018-09-07 12:25:57
  */
 import { SongModel } from '../../models/song'
 import { DEFAULT, PENDING, SUCCESS, FAIL } from '../../const/async-status'
@@ -89,7 +89,6 @@ Page(mergePage(navToggleMixin(['', '歌詞']), {
     wx.nextTick(() => {
       try {
         songModel.getLyric(index, res => {
-          console.log(res.content)
           this.setData({
             content: res.content,
             title: res.title,

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,5 @@
 ### Leona
+- The Radiant Dawn
 
 [![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com)
 


### PR DESCRIPTION
### Changelog
- 添加跳转歌词页入口，暂时通过点击`episode page中的`content-title`进行跳转

### Issue
[#24](https://github.com/tomorrowchuang/leona/issues/24)

![_5477c31c-46dc-4f68-a9cb-156c7d79e0c9](https://user-images.githubusercontent.com/22010181/45198519-866f9480-b299-11e8-84fb-7b29af67c40a.png)


